### PR TITLE
fix: broken link in Verified leaderboard table

### DIFF
--- a/data/leaderboards.json
+++ b/data/leaderboards.json
@@ -1123,7 +1123,7 @@
             "https://se-research.bytedance.com/logos/bytedance.jpg"
           ],
           "site": [
-            "https://seed.bytedance.com/"
+            "https://github.com/bytedance/trae-agent"
           ],
           "folder": "20250928_trae_doubao_seed_code",
           "resolved": 78.8,

--- a/data/leaderboards.json
+++ b/data/leaderboards.json
@@ -1123,7 +1123,6 @@
             "https://se-research.bytedance.com/logos/bytedance.jpg"
           ],
           "site": [
-            "https://github.com/bytedance/trae-agent",
             "https://seed.bytedance.com/"
           ],
           "folder": "20250928_trae_doubao_seed_code",


### PR DESCRIPTION
 ## Summary
  Fixed URL concatenation issue in the Verified leaderboard that prevented the site link from working correctly.
Both links work individually, but when clicking the site icon in the leaderboard, the URLs were being concatenated together in the browser, creating a URL like:
  `https://github.com/bytedance/trae-agent,https://seed.bytedance.com/`
  
  This concatenated URL returned 404.
  