### PR TITLE
Use model_release_date from leaderboard data in release date chart

### DIFF
--- a/js/analysis.js
+++ b/js/analysis.js
@@ -50,7 +50,8 @@
                 resolved: parseFloat(cb.getAttribute('data-resolved')) || 0,
                 cost: cost,
                 per_instance_details: fullModelData?.per_instance_details || null,
-                tags: fullModelData?.tags || null
+                tags: fullModelData?.tags || null,
+                model_release_date: fullModelData?.model_release_date || null
             };
         });
     }

--- a/js/charts/resolvedVsReleaseDateChart.js
+++ b/js/charts/resolvedVsReleaseDateChart.js
@@ -1,9 +1,8 @@
 // Scatter chart for resolved % vs model release date
 function renderResolvedVsReleaseDateChart(ctx, selected, colors, backgroundPlugin) {
-    // Filter models with release dates
+    // Filter models with release dates (prefer inline model_release_date, fallback to JS lookup)
     const modelsWithDates = selected.filter(s => {
-        const releaseDate = getModelReleaseDate(s.tags);
-        return releaseDate !== null;
+        return s.model_release_date || getModelReleaseDate(s.tags);
     });
 
     if (modelsWithDates.length === 0) {
@@ -43,7 +42,7 @@ function renderResolvedVsReleaseDateChart(ctx, selected, colors, backgroundPlugi
 
     // Prepare scatter data
     const scatterData = modelsWithDates.map(s => {
-        const releaseDateInt = getModelReleaseDate(s.tags);
+        const releaseDateInt = s.model_release_date || getModelReleaseDate(s.tags);
         const releaseDate = parseReleaseDateInt(releaseDateInt);
         return {
             x: releaseDate.getTime(),
@@ -139,7 +138,8 @@ function renderResolvedVsReleaseDateChart(ctx, selected, colors, backgroundPlugi
                     callbacks: {
                         label: (ctx) => {
                             const model = modelsWithDates[ctx.dataIndex];
-                            const releaseDate = parseReleaseDateInt(getModelReleaseDate(model.tags));
+                            const releaseDateInt = model.model_release_date || getModelReleaseDate(model.tags);
+                            const releaseDate = parseReleaseDateInt(releaseDateInt);
                             const formattedDate = formatReleaseDate(releaseDate);
                             return `${model.name}: ${formattedDate}, ${ctx.parsed.y.toFixed(2)}%`;
                         }


### PR DESCRIPTION
## Summary
- Pass `model_release_date` through `getSelectedModels()` in `analysis.js`
- Update `resolvedVsReleaseDateChart.js` to prefer `model_release_date` from leaderboard JSON data, falling back to the `modelReleaseDates.js` lookup table for external submissions
- Frontend counterpart to the metadata.yaml changes in the experiments repo

## Test plan
- [ ] Run `make serve` and verify the "Resolved vs model release date" scatter chart still works
- [ ] Verify models with inline dates render correctly
- [ ] Verify external submissions (without inline dates) still fall back to the JS lookup