### PR TITLE
add hugging face link to sidebar footer

### DIFF
--- a/templates/_sidebar.html
+++ b/templates/_sidebar.html
@@ -55,6 +55,10 @@
         <a href="https://join.slack.com/t/swe-bench/shared_invite/zt-3rljl10bn-WED_gNRuFQu6YcILJMgeSw" target="_blank" rel="noopener noreferrer" aria-label="Join the SWE-bench Slack">
             <i class="fab fa-slack"></i>
         </a>
+        &nbsp;
+        <a href="https://huggingface.co/SWE-bench" target="_blank" rel="noopener noreferrer" aria-label="SWE-bench on Hugging Face">
+            <i class="fab fa-hugging-face"></i>
+        </a>
         <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode">
             <i class="fas fa-moon"></i>
         </button>

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}SWE-bench{% endblock %}</title>
     <link rel="stylesheet" href="css/main.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.2.0/css/all.min.css">
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-H9XFCMDPNS"


### PR DESCRIPTION
Proposal to add a hugging face icon linking to https://huggingface.co/SWE-bench next to the other social icons

this requires font awesome >= 7.2.0 for the official fa-hugging-face glyph, so the stylesheet moves from cdnjs 6.2.0 to jsdelivr 7.2.0. checked that all FA classes used across the site still resolve in 7.2.0 (legacy names are aliased), and verified the rendered site locally in chrome (light and dark mode)

disclaimer: my julien-cto agent helped me write this