### PR TITLE
Fix broken mini-SWE-agent swebench.yaml config links

### DIFF
--- a/data/posts/250808-gpt5.md
+++ b/data/posts/250808-gpt5.md
@@ -56,7 +56,7 @@ In contrast, our `mini` agent is really just this class:
 
 ??? note "SWE-bench config"
 
-    - [Read on GitHub](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/config/extra/swebench.yaml)
+    - [Read on GitHub](https://github.com/swe-agent/mini-swe-agent/blob/main/src/minisweagent/config/benchmarks/swebench.yaml)
 
     ```yaml
     --8<-- "data/posts/250808-gpt5/swebench.yaml"

--- a/templates/pages/verified.html
+++ b/templates/pages/verified.html
@@ -42,7 +42,7 @@
             <details>
                 <summary>Click for more details on the bash-only setup</summary>
                 <ul>
-                    <li>We use <a href="https://github.com/SWE-agent/mini-swe-agent/blob/main/src/minisweagent/config/extra/swebench.yaml">this configuration</a> for all models.</li>
+                    <li>We use <a href="https://github.com/SWE-agent/mini-swe-agent/blob/main/src/minisweagent/config/benchmarks/swebench.yaml">this configuration</a> for all models.</li>
                     <li>The release number in the leaderboard corresponds to the version of the mini-SWE-agent used to run the evaluation.</li>
                     <li>Results of release 1.x and 2.x are not necessarily comparable to each other, as 2.x uses tool calling to invoke actions, whereas 1.x parses action from the output strings. Read more about the changes in the <a href="https://mini-swe-agent.com/latest/advanced/v2_migration/">mini-SWE-agent v2 migration guide</a>.</li>
                     <li>For all results of release 1.x and earlier, the LM temperature is set to 0.0 if the temperature parameter is supported. For all results of release 2.x and later, the temperature parameter is not set.</li>


### PR DESCRIPTION
mini-swe-agent renamed src/minisweagent/config/extra/swebench.yaml to src/minisweagent/config/benchmarks/swebench.yaml (commit 76363d10). 

Update the hrefs on the Verified leaderboard page and in the GPT-5 blog post to point at the new path.